### PR TITLE
alive.sh Added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Kolkata
 
 RUN apt-get -qq update && \
-apt-get -qq install -y curl git aria2 python3 wget unzip python3-pip python3-lxml
+    apt-get -qq install -y curl git aria2 python3 wget unzip python3-pip python3-lxml
 
 RUN curl https://rclone.org/install.sh | bash
 
@@ -14,6 +14,6 @@ COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN chmod +x on_finish.sh startup.sh
+RUN chmod +x on_finish.sh startup.sh alive.sh
 
 CMD ["bash", "startup.sh"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The backend for the [Torrentium](https://github.com/itsZECHS/TorrentiumApp) Andr
 ## Deploy on heroku
 
 Required tools
+
 - [git](https://git-scm.com/downloads)
 - [heroku-cli](https://devcenter.heroku.com/articles/heroku-cli)
 
@@ -42,6 +43,8 @@ Copy the `token` value from the output.
 - The `TEAM_DRIVE_ID` is the id of the team drive where you want to store your downloads.
 
 You can copy this from the output of `rclone config show` (above) or Google Drive's team drive page.
+
+- To avoid Heroku Sleep add `SERVER_URL` and value `<heroku app url>`
 
 ## How to use?
 

--- a/alive.sh
+++ b/alive.sh
@@ -1,0 +1,17 @@
+count=1
+while true ; 
+    do 
+        if [[ ! -v SERVER_URL ]]; then
+            echo "[ ERROR ] SERVER_URL is not set"
+        elif [[ -z "$SERVER_URL" ]]; then
+            echo "[ ERROR ] SERVER_URL is set to the empty string"
+        else
+            x=$(curl -s $SERVER_URL); 
+            echo "[ INFO ] Ping SERVER - $count -  : $SERVER_URL"
+            count=$(($count+1))
+        fi
+        
+        # ping server after every 10 min
+        sleep 600 ;
+        
+done

--- a/startup.sh
+++ b/startup.sh
@@ -25,4 +25,11 @@ aria2c --enable-rpc --rpc-listen-all=true --rpc-listen-port 6800 \
   --user-agent='qBittorrent v4.3.3' --peer-agent='qBittorrent v4.3.3' --peer-id-prefix=-qB4330- \
   --on-download-complete=/app/on_finish.sh --dir=/app/aria2 &
 
+# Ping Heroku server
+PING=true
+if $PING ; then
+    bash alive.sh &
+fi
+
+
 uvicorn src.api:app --host=0.0.0.0 --port="${PORT:-5000}"


### PR DESCRIPTION
As web dynos is being used, for free tier account after `30 min` inactive heroku will sleep the app to save the dynos which result in huge latency or in some case result in permanent sleep unless user manually restart the dynos.

To avoid this situation user can add `SERVER_URL` in environment and `PING` value to `true` ( default value of `PING` is `true`) in `startup.sh`, Script will ping heroku server after every `10 min` ( can be increased or decreased as per user need in `alive.sh` ) to keep heroku app active
> If user dont want to use this feature they can set `PING` value to `false` in `startup.sh`
